### PR TITLE
62 add meta name

### DIFF
--- a/api/meta.go
+++ b/api/meta.go
@@ -3,6 +3,8 @@ package api
 import (
 	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/westlab/door-api/model"
 )
 
 // CreateMeta creates meta data
@@ -20,7 +22,9 @@ func GetMeta(c echo.Context) error {
 // GetMetaByName get a meta data by name
 func GetMetaByName(c echo.Context) error {
 	// TODO: Get Meta
-	return c.JSON(http.StatusOK, "{'hello': 'world'}")
+
+	name := c.Param("name")
+	return c.JSON(http.StatusOK, model.SelectSingleMeta(name))
 }
 
 // UpdateMeta updates meta data

--- a/api/meta.go
+++ b/api/meta.go
@@ -1,8 +1,9 @@
 package api
 
 import (
-	"github.com/labstack/echo"
 	"net/http"
+
+	"github.com/labstack/echo"
 
 	"github.com/westlab/door-api/model"
 )
@@ -24,7 +25,12 @@ func GetMetaByName(c echo.Context) error {
 	// TODO: Get Meta
 
 	name := c.Param("name")
-	return c.JSON(http.StatusOK, model.SelectSingleMeta(name))
+	m := model.SelectSingleMeta(name)
+	if m == nil {
+		return c.JSONBlob(http.StatusOK, []byte("{}"))
+		//return c.JSON(http.StatusOK, )
+	}
+	return c.JSON(http.StatusOK, m)
 }
 
 // UpdateMeta updates meta data

--- a/api/meta.go
+++ b/api/meta.go
@@ -22,13 +22,10 @@ func GetMeta(c echo.Context) error {
 
 // GetMetaByName get a meta data by name
 func GetMetaByName(c echo.Context) error {
-	// TODO: Get Meta
-
 	name := c.Param("name")
 	m := model.SelectSingleMeta(name)
 	if m == nil {
 		return c.JSONBlob(http.StatusOK, []byte("{}"))
-		//return c.JSON(http.StatusOK, )
 	}
 	return c.JSON(http.StatusOK, m)
 }

--- a/db/init.sql
+++ b/db/init.sql
@@ -22,6 +22,7 @@ CREATE TABLE IF NOT EXISTS meta (
   id int(11) NOT NULL AUTO_INCREMENT,
   name varchar(255) NOT NULL,
   value text,
+  created_at timestamp DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (id),
   UNIQUE KEY unique_meta_on_name (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/model/meta.go
+++ b/model/meta.go
@@ -12,14 +12,9 @@ import (
 
 // Meta is meta information for door api
 type Meta struct {
-	Name      string    `db:"name" json:"name"`
-	Value     string    `db:"value" json:"value"`
-	CreatedAt time.Time `db:"created_at" json:"created_at"`
-}
-type DummyMeta struct {
-	Name      string `db:"name" json:"name"`
-	Value     string `db:"value" json:"value"`
-	CreatedAt string `db:"created_at" json:"created_at"`
+	Name      string       `db:"name" json:"name"`
+	Value     string       `db:"value" json:"value"`
+	CreatedAt dbr.NullTime `db:"created_at" json:"created_at"`
 }
 
 // ToInt converts value to int64
@@ -41,11 +36,12 @@ func NewMeta(name string, value string) Meta {
 }
 
 // Select from table
-func SelectSingleMeta(name string) DummyMeta {
-	var smeta DummyMeta
+func SelectSingleMeta(name string) *Meta {
+	var m *Meta
+
 	conf := conf.GetConf()
 	conn, _ := dbr.Open(conf.DBType, conf.GetDSN(), nil)
 	sess := conn.NewSession(nil)
-	sess.Select("name", "value", "created_at").From("meta").Where("name = ?", name).LoadStruct(&smeta)
-	return smeta
+	sess.Select("name", "value", "created_at").From("meta").Where("name = ?", name).LoadStruct(&m)
+	return m
 }

--- a/model/meta.go
+++ b/model/meta.go
@@ -3,13 +3,23 @@ package model
 import (
 	"strconv"
 	"time"
+
+	// lib for mysql
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gocraft/dbr"
+	"github.com/westlab/door-api/conf"
 )
 
 // Meta is meta information for door api
 type Meta struct {
 	Name      string    `db:"name" json:"name"`
 	Value     string    `db:"value" json:"value"`
-	CreatedAt time.Time `db:created_at json:"created_at"`
+	CreatedAt time.Time `db:"created_at" json:"created_at"`
+}
+type DummyMeta struct {
+	Name      string `db:"name" json:"name"`
+	Value     string `db:"value" json:"value"`
+	CreatedAt string `db:"created_at" json:"created_at"`
 }
 
 // ToInt converts value to int64
@@ -24,8 +34,18 @@ func (m *Meta) ToBool() bool {
 	return b
 }
 
-// NewMeta creates a new Meata
+// NewMeta creates a new Meta
 func NewMeta(name string, value string) Meta {
 	// TODO: implement add Meta using dbr
 	return Meta{}
+}
+
+// Select from table
+func SelectSingleMeta(name string) DummyMeta {
+	var smeta DummyMeta
+	conf := conf.GetConf()
+	conn, _ := dbr.Open(conf.DBType, conf.GetDSN(), nil)
+	sess := conn.NewSession(nil)
+	sess.Select("name", "value", "created_at").From("meta").Where("name = ?", name).LoadStruct(&smeta)
+	return smeta
 }

--- a/model/meta.go
+++ b/model/meta.go
@@ -2,7 +2,6 @@ package model
 
 import (
 	"strconv"
-	"time"
 
 	// lib for mysql
 	_ "github.com/go-sql-driver/mysql"

--- a/model/meta.go
+++ b/model/meta.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"fmt"
 	"strconv"
 
 	// lib for mysql
@@ -26,6 +27,15 @@ func (m *Meta) ToInt() int64 {
 func (m *Meta) ToBool() bool {
 	b, _ := strconv.ParseBool(m.Value)
 	return b
+}
+
+// Override MarshalJSON
+func (m *Meta) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf(
+		"{\"name\":\"%s\", \"value\":\"%s\", \"created_at\":\"%s\"}",
+		m.Name,
+		m.Value,
+		m.CreatedAt.Time.Format("2006-01-02 15:04:05"))), nil
 }
 
 // NewMeta creates a new Meta

--- a/test/test_data.sql
+++ b/test/test_data.sql
@@ -68,10 +68,22 @@ CREATE TABLE `meta` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `value` text,
+  `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_meta_on_name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
+LOCK TABLES `meta` WRITE;
+/*!40000 ALTER TABLE `meta` DISABLE KEYS */;
+
+INSERT INTO `meta` (`id`, `name`, `value`, `created_at`)
+VALUES
+	(1,'door-version','1.0','2016-04-01 00:00:00'),
+	(2,'door-last-update','2016-04-02 00:00:00','2016-04-03 00:00:00'),
+	(3,'door-version-new','2.0','2016-04-03 00:00:00');
+
+/*!40000 ALTER TABLE `meta` ENABLE KEYS */;
+UNLOCK TABLES;
 
 
 # Dump of table word


### PR DESCRIPTION
#62 用です。

`Meta`構造体の`CreateAt`がtime.Time型では、SQLからLOADされないので、
`DummyMeta`というのを作ってstring型にして仕様通りとなるよう、現状対応しました。

また、テストSQLと初期化SQLのmetaテーブル部分を追記しました。

![screenshot](https://cloud.githubusercontent.com/assets/9294726/14895684/d4f7faca-0db4-11e6-8ad7-05d479d32671.png)
