### PR TITLE
24 browsing histogram

### DIFF
--- a/common/functools.go
+++ b/common/functools.go
@@ -6,15 +6,13 @@ import (
 )
 
 type TimeTuple struct {
-	x, y time.Time
+	X, Y time.Time
 }
 
 // ZipTime performs python like zip
 func ZipTime(x, y []time.Time) []TimeTuple {
 	num := int64(math.Min(float64(len(x)), float64(len(y))))
-
 	r := make([]TimeTuple, num, num)
-
 	for i := 0; i < int(num); i++ {
 		r[i] = TimeTuple{x[i], y[i]}
 	}

--- a/common/functools.go
+++ b/common/functools.go
@@ -1,0 +1,31 @@
+package common
+
+import (
+	"math"
+	"time"
+)
+
+type TimeTuple struct {
+	x, y time.Time
+}
+
+// ZipTime performs python like zip
+func ZipTime(x, y []time.Time) []TimeTuple {
+	num := int64(math.Min(float64(len(x)), float64(len(y))))
+
+	r := make([]TimeTuple, num, num)
+
+	for i := 0; i < int(num); i++ {
+		r[i] = TimeTuple{x[i], y[i]}
+	}
+	return r
+}
+
+// PairwiseTime makes a pair from given sequence
+func PairwiseTime(t []time.Time) []TimeTuple {
+	x := make([]time.Time, len(t))
+	copy(x, t)
+	// delete first element
+	x = x[1:]
+	return ZipTime(t, x)
+}

--- a/common/functools_test.go
+++ b/common/functools_test.go
@@ -18,8 +18,8 @@ func TestZipTime(t *testing.T) {
 	timeZip := ZipTime(s1, s2)
 
 	assert.Equal(t, 10, len(timeZip))
-	assert.Equal(t, timeZip[0].x, timeZip[0].y)
-	assert.Equal(t, timeZip[9].x, timeZip[9].y)
+	assert.Equal(t, timeZip[0].X, timeZip[0].Y)
+	assert.Equal(t, timeZip[9].X, timeZip[9].Y)
 
 	s3 := make([]time.Time, 5)
 	for i := 0; i < len(s3); i++ {
@@ -28,8 +28,8 @@ func TestZipTime(t *testing.T) {
 	timeZip = ZipTime(s2, s3)
 
 	assert.Equal(t, 5, len(timeZip))
-	assert.Equal(t, timeZip[0].x, timeZip[0].y)
-	assert.Equal(t, timeZip[4].x, timeZip[4].y)
+	assert.Equal(t, timeZip[0].X, timeZip[0].Y)
+	assert.Equal(t, timeZip[4].X, timeZip[4].Y)
 }
 
 func TestPairwiseTime(t *testing.T) {
@@ -41,5 +41,5 @@ func TestPairwiseTime(t *testing.T) {
 
 	timePair := PairwiseTime(s1)
 	assert.Equal(t, 9, len(timePair))
-	assert.Equal(t, timePair[0].y, timePair[1].x)
+	assert.Equal(t, timePair[0].Y, timePair[1].X)
 }

--- a/common/functools_test.go
+++ b/common/functools_test.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestZipTime(t *testing.T) {
+	now := time.Now()
+	s1 := make([]time.Time, 10)
+	s2 := make([]time.Time, len(s1))
+	for i := 0; i < len(s1); i++ {
+		s1[i] = now.Add(time.Duration(i) * time.Second)
+	}
+	copy(s2, s1)
+	timeZip := ZipTime(s1, s2)
+
+	assert.Equal(t, 10, len(timeZip))
+	assert.Equal(t, timeZip[0].x, timeZip[0].y)
+	assert.Equal(t, timeZip[9].x, timeZip[9].y)
+
+	s3 := make([]time.Time, 5)
+	for i := 0; i < len(s3); i++ {
+		s3[i] = s2[i]
+	}
+	timeZip = ZipTime(s2, s3)
+
+	assert.Equal(t, 5, len(timeZip))
+	assert.Equal(t, timeZip[0].x, timeZip[0].y)
+	assert.Equal(t, timeZip[4].x, timeZip[4].y)
+}
+
+func TestPairwiseTime(t *testing.T) {
+	now := time.Now()
+	s1 := make([]time.Time, 10)
+	for i := 0; i < len(s1); i++ {
+		s1[i] = now.Add(time.Duration(i) * time.Second)
+	}
+
+	timePair := PairwiseTime(s1)
+	assert.Equal(t, 9, len(timePair))
+	assert.Equal(t, timePair[0].y, timePair[1].x)
+}

--- a/model/browsing.go
+++ b/model/browsing.go
@@ -3,6 +3,7 @@ package model
 import (
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	// lib for mysql
@@ -150,4 +151,25 @@ func GetBrowsings(q string, size int64) []Browsing {
 	}
 	sess.SelectBySql(sql).Load(&browsings)
 	return browsings
+}
+
+// GetHistogram
+// SELECT
+// {count_condition}
+// FROM (SELECT timestamp FROM browsing_history WHERE timestamp > '{max_time}') AS timestamp_groups
+// """
+//
+// HISTOGRAM_COUNT_FMT = """\
+// COUNT(CASE WHEN timestamp >= '{t_from}' AND timestamp < '{to}' THEN 1 END) AS '{label}'
+// """
+func GetHistogram() []Count {
+	counts := ""
+	since := time.Now()
+	countTemp = "COUNT(CASE WHEN timestamp >= '%s' AND timestamp < '%s' THEN 1 END) AS '%s'"
+	sql := fmt.Sprintf(`
+		SELECT
+		%s
+		FROM (SELECT timestamp FROM browsing WHERE timestamp > '%s') AS timestamp_groups
+	`, counts, since)
+
 }

--- a/model/browsing_test.go
+++ b/model/browsing_test.go
@@ -1,0 +1,63 @@
+package model
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeCountCase(t *testing.T) {
+	start := time.Date(1990, time.November, 24, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Duration(100) * time.Minute)
+	windows := makeHistogramWindow(start, end, int64(10))
+	c := makeCountCase(windows)
+
+	expected := `COUNT(CASE WHEN timestamp >= '1990-11-24 00:00:00' AND timestamp < '1990-11-24 00:10:00' THEN 1 END) AS '0:00',
+COUNT(CASE WHEN timestamp >= '1990-11-24 00:10:00' AND timestamp < '1990-11-24 00:20:00' THEN 1 END) AS '0:10',
+COUNT(CASE WHEN timestamp >= '1990-11-24 00:20:00' AND timestamp < '1990-11-24 00:30:00' THEN 1 END) AS '0:20',
+COUNT(CASE WHEN timestamp >= '1990-11-24 00:30:00' AND timestamp < '1990-11-24 00:40:00' THEN 1 END) AS '0:30',
+COUNT(CASE WHEN timestamp >= '1990-11-24 00:40:00' AND timestamp < '1990-11-24 00:50:00' THEN 1 END) AS '0:40',
+COUNT(CASE WHEN timestamp >= '1990-11-24 00:50:00' AND timestamp < '1990-11-24 01:00:00' THEN 1 END) AS '0:50',
+COUNT(CASE WHEN timestamp >= '1990-11-24 01:00:00' AND timestamp < '1990-11-24 01:10:00' THEN 1 END) AS '1:00',
+COUNT(CASE WHEN timestamp >= '1990-11-24 01:10:00' AND timestamp < '1990-11-24 01:20:00' THEN 1 END) AS '1:10',
+COUNT(CASE WHEN timestamp >= '1990-11-24 01:20:00' AND timestamp < '1990-11-24 01:30:00' THEN 1 END) AS '1:20'`
+	assert.Equal(t, expected, c)
+}
+
+func TestMakeHistogramWindow(t *testing.T) {
+	start := time.Date(1990, time.November, 24, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Duration(100) * time.Minute)
+	windows := makeHistogramWindow(start, end, int64(10))
+	assert.Equal(t, 9, len(windows))
+	assert.Equal(t, windows[0].Y, windows[1].X)
+	assert.Equal(t, windows[7].Y, windows[8].X)
+}
+
+func TestMakeUnpivotHistogram(t *testing.T) {
+	start := time.Date(1990, time.November, 24, 0, 0, 0, 0, time.UTC)
+	end := start.Add(time.Duration(100) * time.Minute)
+	windows := makeHistogramWindow(start, end, int64(10))
+	unp := unpivotHistogram(windows, "browsing_histogram")
+	unions := []string{
+		"SELECT '0:00' AS name, `browsing_histogram`.`0:00` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '0:10' AS name, `browsing_histogram`.`0:10` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '0:20' AS name, `browsing_histogram`.`0:20` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '0:30' AS name, `browsing_histogram`.`0:30` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '0:40' AS name, `browsing_histogram`.`0:40` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '0:50' AS name, `browsing_histogram`.`0:50` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '1:00' AS name, `browsing_histogram`.`1:00` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '1:10' AS name, `browsing_histogram`.`1:10` FROM `browsing_histogram`",
+		"UNION ALL",
+		"SELECT '1:20' AS name, `browsing_histogram`.`1:20` FROM `browsing_histogram`"}
+	expected := strings.Join(unions, "\n")
+	assert.Equal(t, expected, unp)
+}


### PR DESCRIPTION
close #24

与えられた任意の時間ないでカウントし、成形のためにunpivotするSQLの自動生成

``` sql
CREATE OR REPLACE VIEW v AS
SELECT
COUNT(CASE WHEN timestamp >= '2016-03-01 00:10:00' AND timestamp < '2016-04-02 00:20:00' THEN 1 END) AS '0:10',
COUNT(CASE WHEN timestamp >= '2016-04-02 00:20:00' AND timestamp < '2016-05-01 00:30:00' THEN 1 END) AS '0:20'
FROM (SELECT timestamp FROM browsing WHERE timestamp > '2016-03-01 00:00:00') AS timestamp_groups;

SELECT * FROM(
SELECT '0:10' AS name, v.`0:10` AS count FROM v
UNION ALL
SELECT '0:20' AS name, v.`0:20` AS count FROM v
) as v_histogram;
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/westlab/door-api/80)

<!-- Reviewable:end -->
