### PR TITLE
add donwloadHTML and removeHTMLtags

### DIFF
--- a/dev/vagrant/Vagrantfile
+++ b/dev/vagrant/Vagrantfile
@@ -51,7 +51,7 @@ Vagrant.configure(2) do |config|
   # config.vm.synced_folder "../data", "/vagrant_data"
 
   # Define door-api synced_folder location
-  config.vm.synced_folder "../../door-api", "/usr/local/go/src/github.com/westlab/door-api"
+  config.vm.synced_folder "../../../door-api", "/usr/local/go/src/github.com/westlab/door-api"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 032bbf33419e93da7a7585654ceb9c20e62a83abd9a3adb459ebe090fe1cf1e2
-updated: 2016-04-25T16:29:54.322423097+09:00
+updated: 2016-05-11T09:57:50.232748999-04:00
 imports:
 - name: github.com/go-sql-driver/mysql
   version: 7ebe0a500653eeb1859664bed5e48dec1e164e73
@@ -7,6 +7,8 @@ imports:
   version: 78b5b74da0b8bcbe167cc4c55d3383b6893848c3
   subpackages:
   - dialect
+- name: github.com/kennygrant/sanitize
+  version: ce9fd1f6ce32afaa38b51feea32320fc8875e8e4
 - name: github.com/labstack/echo
   version: 288164d00a1c6f256c2655e96476be4b65f7629c
   subpackages:
@@ -38,6 +40,8 @@ imports:
   version: fb93926129b8ec0056f2f458b1f519654814edf0
   subpackages:
   - context
+  - html
+  - html/atom
 - name: golang.org/x/sys
   version: f64b50fbea64174967a8882830d621a18ee1548e
   subpackages:

--- a/job/html_analyzer.go
+++ b/job/html_analyzer.go
@@ -1,1 +1,30 @@
 package job
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/kennygrant/sanitize"
+)
+
+func DonwloadHTML(url string) (html string, err error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		log.Fatal(err)
+		return html, err
+	}
+	defer resp.Body.Close()
+	contents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+		return html, err
+	}
+	html = string(contents)
+	return html, nil
+}
+
+func RemoveHTMLTags(html string) string {
+	html = sanitize.HTML(html)
+	return html
+}

--- a/job/html_analyzer_test.go
+++ b/job/html_analyzer_test.go
@@ -1,0 +1,15 @@
+package job
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRemoveHTMLTags(t *testing.T) {
+	html := `<html><head><meta charset="utf-8"></head>
+	<body><div>WestLab</div></body></html>`
+	text := strings.TrimSpace(RemoveHTMLTags(html))
+	assert.Equal(t, "WestLab", text)
+}


### PR DESCRIPTION
`DownloadHTML`ではアクセス不可時では、空文字とエラーが返ります。

`RemoveHTMLTags`では
[https://github.com/kennygrant/sanitize](https://github.com/kennygrant/sanitize)
をそのまま利用で、`glide.lock`を更新しました。
